### PR TITLE
Fix env loading in main

### DIFF
--- a/src/a2a/main.py
+++ b/src/a2a/main.py
@@ -1,13 +1,18 @@
 import os
-from dotenv import load_dotenv
+
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - fallback for environments without python-dotenv
+    def load_dotenv(*args, **kwargs):
+        """Fallback no-op when python-dotenv is unavailable."""
+        return False
 
 load_dotenv()
 
-API_KEY = os.getenv("OPENAI_API_KEY")
-
 def main():
+    api_key = os.getenv("OPENAI_API_KEY")
     print("Welcome to agent2agent project!")
-    print(f"OPENAI_API_KEY set: {bool(API_KEY)}")
+    print(f"OPENAI_API_KEY set: {bool(api_key)}")
 
 if __name__ == "__main__":
     main() 


### PR DESCRIPTION
## Summary
- handle missing `python-dotenv` gracefully
- retrieve API key at runtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779ab17750832cb5c897550ccc12d1